### PR TITLE
CommandBar IOS v1.1.3

### DIFF
--- a/CommandBarIOS.podspec
+++ b/CommandBarIOS.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CommandBarIOS'
-  s.version          = '1.1.2'
+  s.version          = '1.1.3'
   s.summary          = 'HelpHub and Copilot Command Bar for iOS. '
 
 # This description is used to generate tags and improve search results.

--- a/Example/CommandBarIOS/Info.plist
+++ b/Example/CommandBarIOS/Info.plist
@@ -31,6 +31,28 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>processing</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
@@ -42,22 +64,5 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 	</array>
-  <key>UIApplicationSceneManifest</key>
-  <dict>
-      <key>UIApplicationSupportsMultipleScenes</key>
-      <false/>
-      <key>UISceneConfigurations</key>
-      <dict>
-          <key>UIWindowSceneSessionRoleApplication</key>
-          <array>
-              <dict>
-                  <key>UISceneConfigurationName</key>
-                  <string>Default Configuration</string>
-                  <key>UISceneDelegateClassName</key>
-                  <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-              </dict>
-          </array>
-      </dict>
-    </dict>
 </dict>
 </plist>

--- a/Example/CommandBarIOS/Views/HomeView.swift
+++ b/Example/CommandBarIOS/Views/HomeView.swift
@@ -30,6 +30,10 @@ struct HomeView: View {
                             // 3. Track Events
                             CommandBarSDK.shared.trackEvent(event: "test_event")
                         }
+                        CustomButton(title: "Open HelpHub") {
+                            // 4. Open HelpHub
+                            CommandBarSDK.shared.openHelpHub()
+                        }
                     }
                 }.padding(.horizontal)
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CommandBarIOS (1.1.2)
+  - CommandBarIOS (1.1.3)
 
 DEPENDENCIES:
   - CommandBarIOS (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CommandBarIOS: accfb46b06204862926b21ff7ed5462bd48dd1c5
+  CommandBarIOS: a2488351a2817e24355952ad885fbe2deaaa5031
 
 PODFILE CHECKSUM: 6d9bb10e6d829f27934a51717623c1fd87cac734
 

--- a/Example/Pods/Local Podspecs/CommandBarIOS.podspec.json
+++ b/Example/Pods/Local Podspecs/CommandBarIOS.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "CommandBarIOS",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "summary": "HelpHub and Copilot Command Bar for iOS.",
   "description": "TODO: Add long description of the pod here.",
   "homepage": "https://github.com/tryfoobar/CommandBarIOS",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/tryfoobar/CommandBarIOS.git",
-    "tag": "1.1.2"
+    "tag": "1.1.3"
   },
   "platforms": {
     "ios": "13.0"

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CommandBarIOS (1.1.2)
+  - CommandBarIOS (1.1.3)
 
 DEPENDENCIES:
   - CommandBarIOS (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CommandBarIOS: accfb46b06204862926b21ff7ed5462bd48dd1c5
+  CommandBarIOS: a2488351a2817e24355952ad885fbe2deaaa5031
 
 PODFILE CHECKSUM: 6d9bb10e6d829f27934a51717623c1fd87cac734
 

--- a/Example/Pods/Target Support Files/CommandBarIOS/CommandBarIOS-Info.plist
+++ b/Example/Pods/Target Support Files/CommandBarIOS/CommandBarIOS-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.1.2</string>
+  <string>1.1.3</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Sources/CommandBarIOS/CommandBar/Options.swift
+++ b/Sources/CommandBarIOS/CommandBar/Options.swift
@@ -19,7 +19,8 @@ public struct CommandBarOptions : CommandBarOptionsDelegate, Codable {
 internal enum LaunchCode: String, Codable {
     case prod = "prod"
     case labs = "labs"
-    case localDev = "local-dev"
+    case local = "local"
+    case dev = "dev"
 }
 
 internal struct CommandBarInternalOptions : CommandBarOptionsDelegate, Codable {
@@ -64,7 +65,10 @@ internal struct CommandBarInternalOptions : CommandBarOptionsDelegate, Codable {
         case .labs:
             baseURLStr = "https://api-labs.commandbar.com"
             break;
-        case .localDev:
+        case .dev:
+            baseURLStr = "https://api-dev.commandbar.com"
+            break;
+        case .local:
             baseURLStr = "http://localhost:8000"
             break
         default:

--- a/Sources/CommandBarIOS/CommandBar/SDK.swift
+++ b/Sources/CommandBarIOS/CommandBar/SDK.swift
@@ -48,6 +48,10 @@ public final class CommandBarSDK {
         commandbar?.openHelpHub()
     }
     
+    public func closeHelpHub() {
+        guard let orgId = CommandBarSDK.shared.orgId else { return }
+        commandbar?.closeHelpHub()
+    }
 }
 
 extension CommandBarSDK : CommandBarInternalSDKDelegate {

--- a/Sources/CommandBarIOS/HelpHub/HelpHubWebView.swift
+++ b/Sources/CommandBarIOS/HelpHub/HelpHubWebView.swift
@@ -42,9 +42,9 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
         let html = """
             <!DOCTYPE html>
             <html>
-            <head>
+              <head>
                   <meta name="viewport" content="user-scalable=no, width=device-width, height=device-height, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
-                <style>
+                  <style>
                       .loading-container {
                           display: flex;
                           justify-content: center;
@@ -88,23 +88,18 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
                         }
                       }
 
-                    #helphub-close-button {
-                        display: none !important;
-                    }
-                    
-                    #copilot-container:not(:focus-within) {
-                        padding-bottom: 50px;
-                    }
-        
-                    body {
-                        background: transparent;
-                        inset: 2px;
-                    }
-                </style>
-            </head>
-            <body>
-                <div class="loading-container"><div class="lds-ring"><div></div><div></div><div></div><div></div></div></div>
-            </body>
+                      #helphub-close-button {
+                          display: none !important;
+                      }
+                      
+                      #copilot-container:not(:focus-within) {
+                          padding-bottom: 50px;
+                      }
+                  </style>
+              </head>
+              <body>
+                  <div class="loading-container"><div class="lds-ring"><div></div><div></div><div></div><div></div></div></div>
+              </body>
             </html>
         """
         loadHTMLString(html, baseURL: URL(string: "http://api.commandbar.com"))
@@ -116,7 +111,7 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
         }
 
         let userId = options.userId == nil ? "null" : "\"\(options.userId!)\""
-        
+
         let snippet = """
             (function() {
                     window._cbIsWebView = true;
@@ -139,6 +134,22 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         loadSnippet()
+    }
+    
+    // MARK: - WKUIDelegate
+    public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
+        if let frame = navigationAction.targetFrame,
+            frame.isMainFrame {
+            return nil
+        }
+
+        if let url = navigationAction.request.url, UIApplication.shared.canOpenURL(url) {
+            CommandBarSDK.shared.closeHelpHub()
+            UIApplication.shared.open(url)
+            
+        }
+        
+        return nil
     }
 
     // MARK: - WKScriptMessageHandler

--- a/Sources/CommandBarIOS/HelpHub/HelpHubWebView.swift
+++ b/Sources/CommandBarIOS/HelpHub/HelpHubWebView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WebKit
 
-public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandler {
+public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
     public var options: CommandBarOptions_Deprecated? = nil {
         didSet {
             self.loadContent()
@@ -15,6 +15,7 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
     public init(frame: CGRect) {
         super.init(frame: frame, configuration: WKWebViewConfiguration())
         navigationDelegate = self
+        uiDelegate = self
     }
 
     required init?(coder: NSCoder) {
@@ -39,9 +40,54 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
         #endif
 
         let html = """
+            <!DOCTYPE html>
+            <html>
             <head>
-                <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+                  <meta name="viewport" content="user-scalable=no, width=device-width, height=device-height, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
                 <style>
+                      .loading-container {
+                          display: flex;
+                          justify-content: center;
+                          align-items: center;
+                          width: 100%;
+                          height: 100%;
+                      }
+                      .lds-ring {
+                        display: inline-block;
+                        position: relative;
+                        width: 80px;
+                        height: 80px;
+                      }
+                      .lds-ring div {
+                        box-sizing: border-box;
+                        display: block;
+                        position: absolute;
+                        width: 64px;
+                        height: 64px;
+                        margin: 8px;
+                        border: 8px solid \(options.spinnerColor);
+                        border-radius: 50%;
+                        animation: lds-ring 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+                        border-color: \(options.spinnerColor) transparent transparent transparent;
+                      }
+                      .lds-ring div:nth-child(1) {
+                        animation-delay: -0.45s;
+                      }
+                      .lds-ring div:nth-child(2) {
+                        animation-delay: -0.3s;
+                      }
+                      .lds-ring div:nth-child(3) {
+                        animation-delay: -0.15s;
+                      }
+                      @keyframes lds-ring {
+                        0% {
+                          transform: rotate(0deg);
+                        }
+                        100% {
+                          transform: rotate(360deg);
+                        }
+                      }
+
                     #helphub-close-button {
                         display: none !important;
                     }
@@ -59,6 +105,7 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
             <body>
                 <div class="loading-container"><div class="lds-ring"><div></div><div></div><div></div><div></div></div></div>
             </body>
+            </html>
         """
         loadHTMLString(html, baseURL: URL(string: "http://api.commandbar.com"))
     }
@@ -73,7 +120,7 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
         let snippet = """
             (function() {
                     window._cbIsWebView = true;
-                    var o="\(options.orgId)",n=["Object.assign","Symbol","Symbol.for"].join("%2C"),a=window;function t(o,n){void 0===n&&(n=!1),"complete"!==document.readyState&&window.addEventListener("load",t.bind(null,o,n),{capture:!1,once:!0});var a=document.createElement("script");a.type="text/javascript",a.async=n,a.src=o,document.head.appendChild(a)}function r(){var n;if(void 0===a.CommandBar){delete a.__CommandBarBootstrap__;var r=Symbol.for("CommandBar::configuration"),e=Symbol.for("CommandBar::orgConfig"),c=Symbol.for("CommandBar::disposed"),i=Symbol.for("CommandBar::isProxy"),m=Symbol.for("CommandBar::queue"),l=Symbol.for("CommandBar::unwrap"),d=[],s="\(options.launchCode)",u=s&&s.includes("local")?"http://localhost:8000":"https://api.commandbar.com",f=Object.assign(((n={})[r]={uuid:o},n[e]={},n[c]=!1,n[i]=!0,n[m]=new Array,n[l]=function(){return f},n),a.CommandBar),p=["addCommand","boot"],y=f;Object.assign(f,{shareCallbacks:function(){return{}},shareContext:function(){return{}}}),a.CommandBar=new Proxy(f,{get:function(o,n){return n in y?f[n]:p.includes(n)?function(){var o=Array.prototype.slice.call(arguments);return new Promise((function(a,t){o.unshift(n,a,t),f[m].push(o)}))}:function(){var o=Array.prototype.slice.call(arguments);o.unshift(n),f[m].push(o)}}}),null!==s&&d.push("lc=".concat(s)),d.push("version=2"),t("".concat(u,"/latest/").concat(o,"?").concat(d.join("&")),!0)}}void 0===Object.assign||"undefined"==typeof Symbol||void 0===Symbol.for?(a.__CommandBarBootstrap__=r,t("https://polyfill.io/v3/polyfill.min.js?version=3.101.0&callback=__CommandBarBootstrap__&features="+n)):r();
+                    var o="\(options.orgId)",n=["Object.assign","Symbol","Symbol.for"].join("%2C"),a=window;function t(o,n){void 0===n&&(n=!1),"complete"!==document.readyState&&window.addEventListener("load",t.bind(null,o,n),{capture:!1,once:!0});var a=document.createElement("script");a.type="text/javascript",a.async=n,a.src=o,document.head.appendChild(a)}function r(){var n;if(void 0===a.CommandBar){delete a.__CommandBarBootstrap__;var r=Symbol.for("CommandBar::configuration"),e=Symbol.for("CommandBar::orgConfig"),c=Symbol.for("CommandBar::disposed"),i=Symbol.for("CommandBar::isProxy"),m=Symbol.for("CommandBar::queue"),l=Symbol.for("CommandBar::unwrap"),d=[],s="api=\(options.launchCode);commandbar=\(options.launchCode)",u=s&&s.includes("local")?"http://localhost:8000":"https://api.commandbar.com",f=Object.assign(((n={})[r]={uuid:o},n[e]={},n[c]=!1,n[i]=!0,n[m]=new Array,n[l]=function(){return f},n),a.CommandBar),p=["addCommand","boot"],y=f;Object.assign(f,{shareCallbacks:function(){return{}},shareContext:function(){return{}}}),a.CommandBar=new Proxy(f,{get:function(o,n){return n in y?f[n]:p.includes(n)?function(){var o=Array.prototype.slice.call(arguments);return new Promise((function(a,t){o.unshift(n,a,t),f[m].push(o)}))}:function(){var o=Array.prototype.slice.call(arguments);o.unshift(n),f[m].push(o)}}}),null!==s&&d.push("lc=".concat(s)),d.push("version=2"),t("".concat(u,"/latest/").concat(o,"?").concat(d.join("&")),!0)}}void 0===Object.assign||"undefined"==typeof Symbol||void 0===Symbol.for?(a.__CommandBarBootstrap__=r,t("https://polyfill.io/v3/polyfill.min.js?version=3.101.0&callback=__CommandBarBootstrap__&features="+n)):r();
                     window.CommandBar.boot(\(userId), {}, { products: ["help_hub", "nudges"] });
                     window.CommandBar.openHelpHub()
             })();

--- a/Sources/CommandBarIOS/HelpHub/HelpHubWebView.swift
+++ b/Sources/CommandBarIOS/HelpHub/HelpHubWebView.swift
@@ -23,6 +23,8 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
 
     func loadContent() {
         configuration.userContentController.add(self, name: "commandbar__onFallbackAction")
+        configuration.userContentController.add(self, name: "commandbar__log")
+
         configuration.websiteDataStore = WKWebsiteDataStore.default()
         
         guard let options = self.options else {
@@ -96,6 +98,12 @@ public class HelpHubWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHan
 
     public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         guard let actionStr = message.body as? String else {
+            return
+        }
+        
+        // Debug Logging for local development
+        if message.name == "commandbar__log" {
+            print(message.body)
             return
         }
         

--- a/Sources/CommandBarIOS/Types/Nudges.swift
+++ b/Sources/CommandBarIOS/Types/Nudges.swift
@@ -30,7 +30,6 @@ struct NudgeContentVideoBlockMeta : Codable{
 }
 
 struct NudgeContentHelpDocBlockMeta: Codable {
-    var type = "command"
     var command: String?
 }
 
@@ -134,7 +133,6 @@ enum NudgeContentBlockMeta: Codable {
     
     init(from decoder: Decoder, type: NudgeContentBlockType) throws {
         let container = try decoder.singleValueContainer()
-        
         switch type {
         case .markdown:
             let value = try container.decode(NudgeContentMarkdownBlockMeta.self)


### PR DESCRIPTION
Fixes:
- Add `closeHelpHub` SDK Method
- Fix loading spinner not showing in webview
- Allow URLs in webview to either load or open in device browser

Improvements
- Added new internal launch codes
- Added better debug logging support for WebView